### PR TITLE
Use exit code of maven for the action

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set -e
+
 echo "==========Starting Maven Commands=========="
 
 sh -c "mvn $*"


### PR DESCRIPTION
I think `set -e` should be added, so that the action will set the correct status.