### PR TITLE
Update for up to JDK12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.0-jdk-8-alpine
+FROM maven:3.6.0-jdk-12-alpine
 
 LABEL "name"="Maven CLI Action"
 LABEL "maintainer"="Luca Feger <luca@lucafeger.de>"


### PR DESCRIPTION
Many people are up to date and following the new release rate of Open JDK.
I suggest to switch from JDK8 to JDK12 support.